### PR TITLE
Updated kotlinEquals() to use deep array equality

### DIFF
--- a/src/main/kotlin/au/com/console/kassava/AnyExtensions.kt
+++ b/src/main/kotlin/au/com/console/kassava/AnyExtensions.kt
@@ -24,7 +24,15 @@ inline fun <reified T : Any> T.kotlinEquals(other: Any?, properties: Array<out K
         other !is T -> false
         other is SupportsMixedTypeEquality && !other.canEqual(this) -> false
         superEquals != null && !superEquals() -> false
-        else -> properties.all { Objects.equals(it.get(this), it.get(other)) }
+        else -> properties.all {
+            val property = it.get(this)
+            val otherProperty = it.get(other)
+            if (property is Array<*>){
+                Objects.deepEquals(property, otherProperty)
+            } else {
+                Objects.equals(property, otherProperty)
+            }
+        }
     }
 }
 

--- a/src/test/kotlin/au/com/console/kassava/EqualsSpec.kt
+++ b/src/test/kotlin/au/com/console/kassava/EqualsSpec.kt
@@ -92,6 +92,31 @@ class EqualsSpec : Spek({
             }
         }
     }
+
+    given("a company with employees"){
+
+        val company = Company(name = "ACME", employees = arrayOf(Employee(name = "Jim"), Employee(name = "Alice")))
+
+        it("should be equal to a company with the same name and same array of employees"){
+            val otherCompany = Company(name = "ACME", employees = company.employees)
+            assertThat(company, equalTo(otherCompany))
+        }
+
+        it("should be equal to a company with the same name and new array of the same employees (deep equals)"){
+            val otherCompany = Company(name = "ACME", employees = company.employees.copyOf())
+            assertThat(company, equalTo(otherCompany))
+        }
+
+        it("should be equal to a company with the same name and new array of similar employees (deep equals)"){
+            val otherCompany = Company(name = "ACME", employees = arrayOf(Employee(name = "Jim"), Employee(name = "Alice")))
+            assertThat(company, equalTo(otherCompany))
+        }
+
+        it("should not be equal to a company with the same name and slightly different employees"){
+            val otherCompany = Company(name = "ACME", employees = arrayOf(Employee(name = "James"), Employee(name = "Alice")))
+            assertThat(company, !equalTo(otherCompany))
+        }
+    }
 })
 
 /**
@@ -108,6 +133,23 @@ private class Employee(val name: String, val age: Int? = null) {
     override fun toString() = kotlinToString(properties = properties)
 
     override fun hashCode() = Objects.hash(name, age)
+}
+
+/**
+ * Company class - for array field equality.
+ */
+private class Company(val name: String, val employees: Array<Employee>){
+
+    companion object {
+        private val properties = arrayOf(Company::name, Company::employees)
+    }
+
+    override fun equals(other: Any?) = kotlinEquals(other = other, properties = properties)
+
+    override fun toString() = kotlinToString(properties = properties)
+
+    override fun hashCode() = Objects.hash(name, employees)
+
 }
 
 /**


### PR DESCRIPTION
The current implementation is only referential equality for array fields - this PR uses `Objects.deepEquals()` to perform a deep equality check for array fields.

This seems like a good idea, but is there ever any time you wouldn't want this?