### PR TITLE
Add kotlinHashCode method

### DIFF
--- a/src/main/kotlin/au/com/console/kassava/AnyExtensions.kt
+++ b/src/main/kotlin/au/com/console/kassava/AnyExtensions.kt
@@ -36,6 +36,20 @@ inline fun <reified T : Any> T.kotlinEquals(other: Any?, properties: Array<out K
 }
 
 /**
+ * Generates the hash code of an object, based on the supplied properties.
+ *
+ * The implementation uses Java's [Objects.hash] method.
+ *
+ * @param properties the list of properties to use in generating a hash code
+ * @param superHashCode lambda for calling super.hashCode() if required
+ * @param T the type of the receiving class
+ */
+fun <T : Any> T.kotlinHashCode(properties: Array<out KProperty1<T, Any?>>, superHashCode: (() -> Int)? = null): Int {
+    val objects = properties.map { it.get(this) }.toTypedArray()
+    return if (superHashCode != null) Objects.hash(*objects, superHashCode()) else Objects.hash(*objects)
+}
+
+/**
  * Generates the String representation of an object, based on the supplied properties.
  *
  * The implementation is based on the implementation provided by Guava's ToStringHelper (https://github.com/google/guava/wiki/CommonObjectUtilitiesExplained).


### PR DESCRIPTION
Yes, implementing `hashCode()` is trivial thanks to `Objects.hash()`, but this method allows passing a list of properties. If you want to ensure `equals()` and `hashCode()` are based on the same set of properties (which makes holding up their contract easier), you can just pass the same stored list of properties to `kotlinEquals()` and `kotlinHashCode()` and not worry about missing a property.

It's also somewhat verbose, especially for larger objects, to write a property name twice, once to retrieve the property for `equals()` if using `kotlinEquals()` and once to retrieve the value for `hashCode()` if using `Objects.hash()`.